### PR TITLE
Update neon-selection.atom-text-editor.less

### DIFF
--- a/styles/neon-selection.atom-text-editor.less
+++ b/styles/neon-selection.atom-text-editor.less
@@ -11,17 +11,14 @@
     }
 }
 
-.editor .selection,
-atom-text-editor .selection,
-syntax-- .selection {
-    .region {
-        border: 1px solid rgb(97, 210, 255);
-        background: rgba(70, 203, 255, .1) !important;
-        box-shadow: 0 0 4px 0px rgb(75, 213, 255), 0 0 4px 0px rgb(75, 213, 255) inset;
-        opacity: 1 !important;
-    }
-    &.selection-flicker .region {
-        -webkit-animation: neon-selection 0.1s linear infinite;
-    }
+.editor .selection .region,
+atom-text-editor .selection .region,
+atom-text-editor .selection .region {
+    border: 1px solid rgb(97, 210, 255);
+    background: rgba(70, 203, 255, .1) !important;
+    box-shadow: 0 0 4px 0px rgb(75, 213, 255), 0 0 4px 0px rgb(75, 213, 255) inset;
+    -webkit-animation: neon-selection 0.1s linear infinite;
+    opacity: 1 !important;
 }
+
 


### PR DESCRIPTION
Updated syntax-- to conform to newer Atom versions. Tested on my Atom Editor and this simple change should correct the issues before Atom removes the auto selectors for performance reasons. 